### PR TITLE
babel-runtime is production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "license": "ISC",
   "dependencies": {
-    "reflux-core": "^0.3.0"
+    "reflux-core": "^0.3.0",
+    "babel-runtime": "^6.6.1"
   },
   "homepage": "https://github.com/yonatanmn/cartiv",
   "readmeFilename": "README.md",
@@ -48,7 +49,6 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-0": "^6.1.18",
-    "babel-runtime": "^6.6.1",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^6.1.0",
     "eslint-plugin-react": "^4.2.3"


### PR DESCRIPTION
I use Cartiv in my project via usual `npm install --save cartiv`.
It complains with a series of 16 errors about `babel-runtime` modules like:
`Error: Cannot find module 'babel-runtime/helpers/extends' from ...`

Seems `babel-runtime` is a hard (production) dependency instead of only a devDependency.

Manual test/fix:

```
cd node_modules/cartiv/
npm install --save babel-runtime
ls ./node_modules/
==>  babel-runtime  reflux-core
```
